### PR TITLE
feature: add pin5, GPIO0 on the DB50 connector for ROSCube-X

### DIFF
--- a/include/jetson_camera_trigger/jetson_gpio.hpp
+++ b/include/jetson_camera_trigger/jetson_gpio.hpp
@@ -28,7 +28,8 @@ typedef int gpio_direction;
 typedef int gpio_state;
 
 // Mapping of GPIO number to pin number for ROSCubeX
-// Note: pin 5->216 is pin 5 on the DB50 connector, run by GPIO chip 216 (starting at GPIO number 216)
+// Note: pin 5->216 is pin 5 on the DB50 connector, run by GPIO chip 216 (starting at GPIO number
+// 216)
 static std::map<int, int> pin_gpio_mapping{{5, 216}, {51, 408}, {52, 350}, {53, 446}, {54, 445}};
 
 int export_gpio(int gpio);

--- a/include/jetson_camera_trigger/jetson_gpio.hpp
+++ b/include/jetson_camera_trigger/jetson_gpio.hpp
@@ -28,7 +28,8 @@ typedef int gpio_direction;
 typedef int gpio_state;
 
 // Mapping of GPIO number to pin number for ROSCubeX
-static std::map<int, int> pin_gpio_mapping{{51, 408}, {52, 350}, {53, 446}, {54, 445}};
+// Note: pin 5->216 is pin 5 on the DB50 connector, run by GPIO chip 216 (starting at GPIO number 216)
+static std::map<int, int> pin_gpio_mapping{{5, 216}, {51, 408}, {52, 350}, {53, 446}, {54, 445}};
 
 int export_gpio(int gpio);
 int unexport_gpio(int gpio);


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

## Description

This PR adds GPIO0, pin 5 on the DB50 connector of ROSCube-X to the pin map assignments.
It can now be accessed as pin 5 (`gpio:=5`) for use as a trigger output.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

Please check the operation of the GPIO on pin 5 of the DB50 connector, when using `gpio:=5` to launch the trigger node.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
