### PR TITLE
feat: close GPIO port on node boot if is is already used

### DIFF
--- a/src/jetson_gpio.cpp
+++ b/src/jetson_gpio.cpp
@@ -15,6 +15,7 @@
 #include <sensor_trigger/jetson_gpio.hpp>
 
 #include <cstdio>
+#include <sys/stat.h>
 
 namespace jetson_gpio
 {
@@ -64,6 +65,15 @@ bool JetsonGpio::export_gpio()
 {
   int file_descriptor, buffer_length;
   char buffer[BUFFER_SIZE];
+
+  // Check target GPIO is available (not opened) first.
+  // If it is unavailable, close the port and try to open it.
+    std::string target_gpio = std::string(SYSFS_GPIO_DIR) + std::string("/gpio")
+                              + std::to_string(gpio_);
+  struct stat return_status;
+  if (stat(target_gpio.c_str(), &return_status) == 0) {
+       unexport_gpio();
+  }
 
   file_descriptor = open(SYSFS_GPIO_DIR "/export", O_WRONLY);
   if (file_descriptor < 0) {


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->
Currently, if the target GPIO port is opened when the node starts, the node exits with an error status.
This PR checks the status of the target GPIO port, closes it if it is in use, and tries to open it on node boot.
 
## Review Procedure

<!-- Explain how to review this PR. -->
```sh
$ echo 216 > /sys/class/gpio/export 
$ ros2 run sensor_trigger sensor_trigger_exe --ros-args -p gpio:=5
```
Before merging this PR, the node should exit with a message like `Failed to initialize GPIO trigger. ...` while should not after merging

## Remarks

<!-- Write remarks as you like if you need them. -->

Even if there is another process that uses a specified GPIO port properly, the ownership of the GPIO port is forcely taken by this `sensor_trigger` node. This PR intends to make `sensor_trigger` node work properly under the condition that some processes (including previous run of `sensor_trigger`) exit unexpectedly and the target GPIO port is not closed correctly.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
