### PR TITLE
fix: set CPU affinity for trigger thread

### DIFF
--- a/src/sensor_trigger.cpp
+++ b/src/sensor_trigger.cpp
@@ -65,29 +65,28 @@ SensorTrigger::SensorTrigger(const rclcpp::NodeOptions & node_options)
         << gpio_chip_ << "line number " << gpio_line_ << ".");
   }
 
-  // Set CPU affinity
-  cpu_set_t cpuset;
-  CPU_ZERO(&cpuset);
-  CPU_SET(cpu_, &cpuset);
-  if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset)) {
-    RCLCPP_WARN_STREAM(get_logger(), "Failed to set CPU affinity: " << strerror(errno) << ".");
-  }
-  if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset)) {
-    RCLCPP_WARN_STREAM(get_logger(), "Failed to check CPU affinity: " << strerror(errno) << ".");
-  }
-
   // Create thread
   trigger_time_publisher_ = create_publisher<builtin_interfaces::msg::Time>("trigger_time", 1000);
   trigger_thread_ = std::make_unique<std::thread>(&SensorTrigger::run, this);
+
+  // Set CPU affinity for trigger_thread_
+  cpu_set_t cpuset;
+  CPU_ZERO(&cpuset);
+  CPU_SET(cpu_, &cpuset);
+  if (pthread_setaffinity_np(trigger_thread_->native_handle(), sizeof(cpu_set_t), &cpuset)) {
+    RCLCPP_WARN_STREAM(get_logger(), "Failed to set thread CPU affinity: " << strerror(errno) << ".");
+  }
+  if (pthread_getaffinity_np(trigger_thread_->native_handle(), sizeof(cpu_set_t), &cpuset)) {
+    RCLCPP_WARN_STREAM(get_logger(), "Failed to check thread CPU affinity: " << strerror(errno) << ".");
+  }
 
   // Set thread priority
   sched_param sch;
   int policy;
   pthread_getschedparam(trigger_thread_->native_handle(), &policy, &sch);
-  sch.sched_priority = 30;
+  sch.sched_priority = 80;
   if (pthread_setschedparam(trigger_thread_->native_handle(), SCHED_FIFO, &sch)) {
-    RCLCPP_WARN_STREAM(
-      get_logger(), "Failed to set schedule parameters: " << strerror(errno) << ".");
+    RCLCPP_WARN_STREAM(get_logger(), "Failed to set schedule parameters: " << strerror(errno) << ".");
   }
 }
 


### PR DESCRIPTION
## PR Type
- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

This PR adds CPU affinity setting for trigger_thread_ to improve timing consistency of the FSYNC signal. Previously, CPU affinity was only applied to the main thread, and the trigger thread could migrate across CPUs, causing jitter.
By pinning the trigger thread to a dedicated CPU core, FSYNC timing stability is improved.


## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
